### PR TITLE
Allow uppercase hex chars in expressions

### DIFF
--- a/esp32_ulp/util.py
+++ b/esp32_ulp/util.py
@@ -49,23 +49,23 @@ def validate_expression(param):
     for token in split_tokens(param):
         state = 0
         for c in token:
-            if c not in ' \t+-*/%()<>&|~x0123456789abcdef':
+            if c not in ' \t+-*/%()<>&|~xX0123456789abcdefABCDEF':
                 return False
 
             # the following allows hex digits a-f after 0x but not otherwise
             if state == 0:
-                if c in 'abcdef':
+                if c in 'abcdefABCDEF':
                     return False
                 if c == '0':
                     state = 1
                 continue
 
             if state == 1:
-                state = 2 if c == 'x' else 0
+                state = 2 if c in 'xX' else 0
                 continue
 
             if state == 2:
-                if c not in '0123456789abcdef':
+                if c not in '0123456789abcdefABCDEF':
                     state = 0
     return True
 

--- a/tests/compat/expr.S
+++ b/tests/compat/expr.S
@@ -46,3 +46,11 @@ exit:
   move r3, 0x1234 & ~2
   move r3, 42|4&0xf  # 46 (4&0xf is evaluated first)
   move r3, (42|4)&0xf  # 14 (42|4 is evaluated first)
+
+# ---
+# test that expressions accept hex characters in either upper or lower case
+  move r3, 0xaa - 1
+  move r3, 0xBB - 1
+  move r3, 0xCc - 1
+  move r3, 0Xdd - 1
+  move r3, 0XEF - 1

--- a/tests/util.py
+++ b/tests/util.py
@@ -44,6 +44,10 @@ def test_validate_expression():
     assert validate_expression('0x100 & ~2') is True
     assert validate_expression('0xabcdef') is True
     assert validate_expression('0x123def') is True
+    assert validate_expression('0xABC') is True
+    assert validate_expression('0xaBc') is True
+    assert validate_expression('0Xabc') is True
+    assert validate_expression('0X123ABC') is True
     assert validate_expression('2*3+4/5&6|7') is True
     assert validate_expression('(((((1+1) * 2') is True  # valid characters, even if expression is not valid
 
@@ -55,6 +59,7 @@ def test_validate_expression():
     assert validate_expression('123 ^ 4') is False  # operator not supported for now
     assert validate_expression('evil()') is False
     assert validate_expression('def cafe()') is False  # valid hex digits, but potentially dangerous code
+    assert validate_expression('def CAFE()') is False
 
 
 @test


### PR DESCRIPTION
Support uppercase hex character in expressions. 0xFF is now treated identically to 0xff. As is 0Xff or 0xFf.

Resolves #71 