### PR TITLE
Use micropython from new build location during build

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -34,8 +34,9 @@ jobs:
         git describe --always --tags
         make submodules
         make
-        export PATH=$PATH:$PWD
-        echo "::set-output name=bin_dir::$PWD"
+        export OUTDIR=$PWD/build-standard
+        export PATH=$PATH:$OUTDIR
+        echo "::set-output name=bin_dir::$OUTDIR"
         test $(micropython -c 'print("test")') = "test"
         popd
 


### PR DESCRIPTION
The MicroPython project changed their CI scripts slightly, which resulted in the unix port binary being output to a subdirectory (`build-standard`) instead of the current directory as before. This broke our build process.

This commit updates our build script to search for the `micropython` binary in the correct subdirectory.

Fixes #81