### PR TITLE
Update builder image to ubuntu-20.04

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
       with:
@@ -44,6 +44,10 @@ jobs:
       id: build_binutils
       run: |
         echo "Building binutils-esp32ulp"
+        # building requires an older version of gcc
+        sudo apt-get install -y gcc-7 g++-7
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 7
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 7
         git clone --depth 1 https://github.com/espressif/binutils-esp32ulp.git
         pushd binutils-esp32ulp
         git describe --always --tags


### PR DESCRIPTION
GitHub has deprecated the ubuntu-18.04 builder image. So before that builder image is entirely removed, this PR updates the build process to use the ubuntu-20.04 image instead.

This commit also installs an older version of GCC (v7) because [binutils-esp32ulp](https://github.com/espressif/binutils-esp32ulp) does not build successfully on Ubuntu 20.04 with its default GCC version (v9). (Solution was found here: https://github.com/espressif/binutils-esp32ulp/issues/19#issuecomment-945091131)

Fixes: #80

PS: Ubuntu 22.04 no longer has GCC v7 in its repository, which is why this PR only changes to Ubuntu 20.04 for now (should last a while). It appears binutils-esp32ulp has some bigger change in the making ([see this comment](https://github.com/espressif/binutils-esp32ulp/issues/23#issuecomment-1232223265)), which might make it compatible with a newer GCC in the near future, and then perhaps easier for us to update to Ubuntu 22.04.