### PR TITLE
Fix GitHub Deprecation warnings

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         # just fetching 1 commit is not enough for setuptools-scm, so we fetch all
         fetch-depth: 0

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -6,7 +6,7 @@ jobs:
   tests:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 1
 
@@ -36,7 +36,7 @@ jobs:
         make
         export OUTDIR=$PWD/build-standard
         export PATH=$PATH:$OUTDIR
-        echo "::set-output name=bin_dir::$OUTDIR"
+        echo "bin_dir=$OUTDIR" >> $GITHUB_OUTPUT
         test $(micropython -c 'print("test")') = "test"
         popd
 
@@ -56,7 +56,7 @@ jobs:
         make
         make install-strip
         export PATH=$PATH:$PWD/dist/bin
-        echo "::set-output name=bin_dir::$PWD/dist/bin"
+        echo "bin_dir=$PWD/dist/bin" >> $GITHUB_OUTPUT
         esp32ulp-elf-as --version | grep 'esp32ulp-elf' > /dev/null
         popd
 


### PR DESCRIPTION
This commit fixes 2 Github Deprecations:

1. Node12 Actions GitHub deprecated Node12 for running actions. In this commit we're switching to the latest version of action/checkout, which has been updated to run on a newer Node version. See: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

2. set-output/set-state commands GitHub deprecated the ::set-output command which we use to pass PATH information between build steps. This commit switches to echoing a key=value pair to the environment file $GITHUB_OUTPUT. See: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

See the recent [Github Actions run](https://github.com/micropython/micropython-esp32-ulp/actions/runs/5263843356), which flagged those deprecations