### PR TITLE
Use new binutils gdb

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -40,25 +40,32 @@ jobs:
         test $(micropython -c 'print("test")') = "test"
         popd
 
-    - name: Build binutils-esp32ulp
-      id: build_binutils
+    - name: Fetch binutils-esp32ulp
+      id: fetch_binutils
       run: |
-        echo "Building binutils-esp32ulp"
-        # building requires an older version of gcc
-        sudo apt-get install -y gcc-7 g++-7
-        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 7
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 7
-        git clone --depth 1 https://github.com/espressif/binutils-esp32ulp.git
-        pushd binutils-esp32ulp
-        git describe --always --tags
-        ./configure --target=esp32ulp-elf --prefix=$PWD/dist --disable-doc --disable-gdb --disable-libdecnumber --disable-readline --disable-sim
-        echo "MAKEINFO = :" >> Makefile
-        make
-        make install-strip
-        export PATH=$PATH:$PWD/dist/bin
-        echo "bin_dir=$PWD/dist/bin" >> $GITHUB_OUTPUT
+        echo "Fetching URL of pre-built esp32ulp-elf binaries"
+        ## URL to pre-built binaries is published in esp-idf
+        IDFVER=v5.0.1
+        curl -s \
+          -o tools.json \
+          https://raw.githubusercontent.com/espressif/esp-idf/$IDFVER/tools/tools.json
+        URL=$(<tools.json jq -r '
+          .tools[]
+            | select(.name == "esp32ulp-elf").versions[]
+            | select(.status == "recommended")
+            | .["linux-amd64"]
+            | .url
+            // empty
+        ')
+
+        echo "Downloading esp32ulp-elf from $URL"
+        curl -sL \
+           -o /tmp/esp32ulp-elf.tar.gz \
+           $URL
+        tar xfvz /tmp/esp32ulp-elf.tar.gz esp32ulp-elf/bin
+        export PATH=$PATH:$PWD/esp32ulp-elf/bin
+        echo "bin_dir=$PWD/esp32ulp-elf/bin" >> $GITHUB_OUTPUT
         esp32ulp-elf-as --version | grep 'esp32ulp-elf' > /dev/null
-        popd
 
     ###### Run tests ######
 
@@ -73,7 +80,7 @@ jobs:
       id: compat_tests
       run: |
         export PATH=$PATH:${{ steps.build_micropython.outputs.bin_dir }}
-        export PATH=$PATH:${{ steps.build_binutils.outputs.bin_dir }}
+        export PATH=$PATH:${{ steps.fetch_binutils.outputs.bin_dir }}
         cd tests
         ./01_compat_tests.sh
 
@@ -81,7 +88,6 @@ jobs:
       id: compat_rtc_tests
       run: |
         export PATH=$PATH:${{ steps.build_micropython.outputs.bin_dir }}
-        export PATH=$PATH:${{ steps.build_binutils.outputs.bin_dir }}
+        export PATH=$PATH:${{ steps.fetch_binutils.outputs.bin_dir }}
         cd tests
-        ln -s ../binutils-esp32ulp  # already cloned earlier. reuse.
         ./02_compat_rtc_tests.sh

--- a/README.rst
+++ b/README.rst
@@ -18,9 +18,10 @@ It can translate small assembly language programs to a loadable/executable
 ULP machine code binary, directly on the ESP32 microcontroller.
 
 This is intended as an alternative approach to assembling such programs using
-the binutils-esp32ulp toolchain from Espressif on a development machine.
+the `binutils-gdb toolchain <https://github.com/espressif/binutils-gdb/tree/esp32ulp-elf-2.35>`_
+(esp32-elf-as) from Espressif on a development machine.
 
-It can also be useful in cases where binutils-esp32ulp is not available.
+It can also be useful in cases where esp32-elf-as is not available.
 
 
 Features

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -151,7 +151,8 @@ Testing
 -------
 
 There are unit tests and also compatibility tests that check whether the binary
-output is identical with what binutils-esp32ulp produces.
+output is identical with what Espressif's esp32-elf-as (from their `binutils-gdb fork
+<https://github.com/espressif/binutils-gdb/tree/esp32ulp-elf-2.35>`_) produces.
 
 micropython-esp32-ulp has been tested on the Unix port of MicroPython and on real ESP32
 devices with the chip type ESP32D0WDQ6 (revision 1) without SPIRAM.

--- a/tests/01_compat_tests.sh
+++ b/tests/01_compat_tests.sh
@@ -26,7 +26,7 @@ for src_file in $(ls -1 compat/*.S); do
 
     echo -e "\tBuilding using binutils"
     gcc -E -o ${pre_file} $src_file
-    esp32ulp-elf-as -o $obj_file ${pre_file}
+    esp32ulp-elf-as --mcpu=esp32 -o $obj_file ${pre_file}
     esp32ulp-elf-ld -T esp32.ulp.ld -o $elf_file $obj_file
     esp32ulp-elf-objcopy -O binary $elf_file $bin_file
 

--- a/tests/02_compat_rtc_tests.sh
+++ b/tests/02_compat_rtc_tests.sh
@@ -27,12 +27,13 @@ fetch_ulptool_examples() {
 }
 
 fetch_binutils_esp32ulp_examples() {
-    [ -d binutils-esp32ulp ] && return
+    [ -d binutils-gdb ] && return
 
-    echo "Fetching binutils-esp32ulp examples"
+    echo "Fetching binutils-gdb (esp32ulp) examples"
     log_file=log/fetch-binutils.log
     git clone --depth 1 \
-        https://github.com/espressif/binutils-esp32ulp.git 1>$log_file 2>&1
+        -b esp32ulp-elf-v2.35_20220830 \
+        https://github.com/espressif/binutils-gdb.git 1>$log_file 2>&1
 }
 
 build_defines_db() {
@@ -63,7 +64,7 @@ patch_test() {
 
     if [ "${test_name}" = esp32ulp_jumpr ]; then
         (
-            cd binutils-esp32ulp/gas/testsuite/gas/esp32ulp/esp32
+            cd binutils-gdb/gas/testsuite/gas/esp32ulp/esp32
             cp ${test_name}.s ${out_file}
             echo -e "\tPatching test to work around binutils-esp32ulp .global bug"
             cat >> ${out_file} <<EOF
@@ -74,11 +75,11 @@ EOF
 
     elif [ "${test_name}" = esp32ulp_ranges ]; then
         (
-            cd binutils-esp32ulp/gas/testsuite/gas/esp32ulp/esp32
+            cd binutils-gdb/gas/testsuite/gas/esp32ulp/esp32
             # merge 2 files: https://github.com/espressif/binutils-esp32ulp/blob/249ec34/gas/testsuite/gas/esp32ulp/esp32/check_as_ld.sh#L31
             echo -e "\t${test_name} requires esp32ulp_globals. Merging both files into ${out_file}"
             cat esp32ulp_globals.s ${test_name}.s > ${out_file}
-            echo -e "\tPatching test to work around binutils-esp32ulp .global bug"
+            echo -e "\tPatching test to work around binutils-gdb (esp32ulp) .global bug"
             cat >> ${out_file} <<EOF
                 .global min_add
                 .global min_jump1
@@ -99,7 +100,7 @@ fetch_ulptool_examples
 fetch_binutils_esp32ulp_examples
 build_defines_db $1
 
-for src_file in ulptool/src/ulp_examples/*/*.s binutils-esp32ulp/gas/testsuite/gas/esp32ulp/esp32/*.s; do
+for src_file in ulptool/src/ulp_examples/*/*.s binutils-gdb/gas/testsuite/gas/esp32ulp/esp32/*.s; do
 
     src_name="${src_file%.s}"
     src_dir="${src_name%/*}"
@@ -116,7 +117,7 @@ for src_file in ulptool/src/ulp_examples/*/*.s binutils-esp32ulp/gas/testsuite/g
         fi
     done
 
-    # BEGIN: work around known issues with binutils-esp32ulp
+    # BEGIN: work around known issues with binutils-gdb (esp32ulp)
     ulp_file="${src_name}.ulp"
 
     if patch_test ${test_name}; then
@@ -125,7 +126,7 @@ for src_file in ulptool/src/ulp_examples/*/*.s binutils-esp32ulp/gas/testsuite/g
         src_name="${src_file%.tmp}"
         ulp_file="${src_name}.tmp.ulp"  # when extension is not .s, micropython-esp32-ulp doesn't remove original extension
     fi
-    # END: work around known issues with binutils-esp32ulp
+    # END: work around known issues with binutils-gdb (esp32ulp)
 
     echo -e "\tBuilding using micropython-esp32-ulp"
     log_file="${src_name}.log"

--- a/tests/02_compat_rtc_tests.sh
+++ b/tests/02_compat_rtc_tests.sh
@@ -141,7 +141,7 @@ for src_file in ulptool/src/ulp_examples/*/*.s binutils-gdb/gas/testsuite/gas/es
     gcc -I esp-idf/components/soc/esp32/include -I esp-idf/components/esp_common/include \
         -x assembler-with-cpp \
         -E -o ${pre_file} $src_file
-    esp32ulp-elf-as -o $obj_file ${pre_file}
+    esp32ulp-elf-as --mcpu=esp32 -o $obj_file ${pre_file}
     esp32ulp-elf-ld -T esp32.ulp.ld -o $elf_file $obj_file
     esp32ulp-elf-objcopy -O binary $elf_file $bin_file
 


### PR DESCRIPTION
This is a precursor step to adding support for the ULP-FSM of the ESP32-S2/S3.

This change changes where we get the esp32ulp assembler/linker from:
* we now use the latest maintained version (binutils-gdb instead of binutils-esp32ulp)
* we download pre-built binaries, rather than building ourselves - to save time.

Espressif moved where they maintain the ULP assembler (see https://github.com/espressif/esp-idf/commit/a9bd454), and this changes switches to the new esp32ulp assembler/linker, which is also what the latest ESP-IDF uses.

Since Espressif publishes a list of pre-built tools, which includes the esp32ulp assembler/linker, we now download the pre-built binaries, rather than building them ourselves.

The new esp32ulp assembler/linker only has a single set of binaries across all esp32 variants, and esp32ulp-elf-as accepts the --mcpu argument to select the specific variant.

For now we explicitly choose --mcpu=esp32 (even though that is the default) in our existing tests, but when adding support for the S2 (and S3, which has the same binary format) we can simply specify --mcpu=esp32s2 in the tests that target the S2.