### PR TITLE
Add package.json for MIP package manager

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,8 +62,13 @@ To get going run the following directly on the ESP32:
 
 .. code-block:: python
 
-   # Step 1: Install micropython-esp32-ulp
    # IMPORTANT: Ensure the ESP32 is connected to a network with internet connectivity.
+
+   # Step 1: Install micropython-esp32-ulp (for MicroPython v1.20 or newer)
+   import mip
+   mip.install('github:micropython/micropython-esp32-ulp')
+
+   # Step 1: Install micropython-esp32-ulp (for MicroPython older than v1.20)
    import upip
    upip.install('micropython-esp32-ulp')
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,11 +13,17 @@ Overview
 Installation
 ------------
 
-On the ESP32, install using upip:
+On the ESP32, install using mip (or upip on older MicroPythons):
 
 .. code-block:: python
 
-   # ensure the ESP32 is connected to a network with internet connectivity
+   # step 1: ensure the ESP32 is connected to a network with internet connectivity
+
+   # step 2 (for MicroPython 1.20 or newer)
+   import mip
+   mip.install('github:micropython/micropython-esp32-ulp')
+
+   # step 2 (for MicroPython older than 1.20)
    import upip
    upip.install('micropython-esp32-ulp')
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "v":1,
+  "urls":[
+    ["esp32_ulp/__init__.py", "github:micropython/micropython-esp32-ulp/esp32_ulp/__init__.py"],
+    ["esp32_ulp/__main__.py", "github:micropython/micropython-esp32-ulp/esp32_ulp/__main__.py"],
+    ["esp32_ulp/assemble.py", "github:micropython/micropython-esp32-ulp/esp32_ulp/assemble.py"],
+    ["esp32_ulp/definesdb.py", "github:micropython/micropython-esp32-ulp/esp32_ulp/definesdb.py"],
+    ["esp32_ulp/link.py", "github:micropython/micropython-esp32-ulp/esp32_ulp/link.py"],
+    ["esp32_ulp/nocomment.py", "github:micropython/micropython-esp32-ulp/esp32_ulp/nocomment.py"],
+    ["esp32_ulp/opcodes.py", "github:micropython/micropython-esp32-ulp/esp32_ulp/opcodes.py"],
+    ["esp32_ulp/opcodes_s2.py", "github:micropython/micropython-esp32-ulp/esp32_ulp/opcodes_s2.py"],
+    ["esp32_ulp/parse_to_db.py", "github:micropython/micropython-esp32-ulp/esp32_ulp/parse_to_db.py"],
+    ["esp32_ulp/preprocess.py", "github:micropython/micropython-esp32-ulp/esp32_ulp/preprocess.py"],
+    ["esp32_ulp/soc.py", "github:micropython/micropython-esp32-ulp/esp32_ulp/soc.py"],
+    ["esp32_ulp/soc_s2.py", "github:micropython/micropython-esp32-ulp/esp32_ulp/soc_s2.py"],
+    ["esp32_ulp/soc_s3.py", "github:micropython/micropython-esp32-ulp/esp32_ulp/soc_s3.py"],
+    ["esp32_ulp/util.py", "github:micropython/micropython-esp32-ulp/esp32_ulp/util.py"]
+  ]
+}

--- a/tools/genpkgjson.py
+++ b/tools/genpkgjson.py
@@ -1,0 +1,50 @@
+"""
+Tool for generating package.json for the MIP package manager
+
+Run this tool from the repo root, like:
+
+python tools/genpkgjson.py > package.json
+
+Note:
+This tool works with both python3 and micropyton.
+"""
+
+import os
+import json
+
+PACKAGE_JSON_VERSION=1
+
+# Update the repo when working with a fork
+GITHUB_REPO="micropython/micropython-esp32-ulp"
+
+
+def get_files(path):
+    files = [f'{path}/{f}' for f in os.listdir(path)]
+    return files
+
+
+def build_urls(repo_base, files):
+    return [[f, f'github:{repo_base}/{f}'] for f in files]
+
+
+def print_package_json(urls):
+    """
+    Custom-formatting JSON output for better readability
+
+    json.dumps in MicroPython cannot format the output and python3
+    puts each element of each urls' sub-arrays onto a new line.
+    Here we print each file and its source url onto the same line.
+    """
+    print('{')
+    print(f'  "v":{PACKAGE_JSON_VERSION},')
+    print('  "urls":[')
+    print(',\n'.join([f'    {json.dumps(u)}' for u in sorted(urls)]))
+    print('  ]')
+    print('}')
+
+
+if __name__ == '__main__':
+    library_root = 'esp32_ulp'
+    files = get_files(library_root)
+    urls = build_urls(GITHUB_REPO, files)
+    print_package_json(urls)


### PR DESCRIPTION
This PR adds a `package.json` file to allow installing `micropython-esp32-ulp` with the `mip` package manager on modern MicroPythons.

To install with mip, one would run:
```py
import mip
mip.install('github:micropython/micropython-esp32-ulp')

# note: while this PR is not merged, this command can be used for testing instead
mip.install('https://raw.githubusercontent.com/wnienhaus/micropython-esp32-ulp/mip_support/package.json')
```

This PR also adds a tool for generating the contents of `package.json`, so it doesn't have to be handcrafted whenever files are added/removed.

To generate/update `package.json`, run from repo root as follows:

```py
python3 tools/genpkgjson.py > package.json
```
(instead of `python3`, `micropython` can also be used)

Note: at present MIP does not support any way to specify repo-relative urls, so at present the generated json will point to `gituhub:micropython/micropython-esp32-ulp`, and when working with forks of this repo, that url would need to be adjusted to point to the fork instead of this repo.

Closes #93 