### PR TITLE
Add licence headers to all source files

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 name: Publish Python Package
 
 on:

--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 name: CI
 
 on: [push, pull_request]

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright 2018-2022 by the micropython-esp32-ulp authors, see AUTHORS file
+Copyright 2018-2023 by the micropython-esp32-ulp authors, see AUTHORS file
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/demo.S
+++ b/demo.S
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 # comment-only line
 
             .text

--- a/demo.sh
+++ b/demo.sh
@@ -1,1 +1,8 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 micropython -m esp32_ulp demo.S

--- a/esp32_ulp/__init__.py
+++ b/esp32_ulp/__init__.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 from .util import garbage_collect
 
 from .preprocess import preprocess

--- a/esp32_ulp/__main__.py
+++ b/esp32_ulp/__main__.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 import sys
 from . import assemble_file
 

--- a/esp32_ulp/assemble.py
+++ b/esp32_ulp/assemble.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 """
 ESP32 ULP Co-Processor Assembler
 """

--- a/esp32_ulp/definesdb.py
+++ b/esp32_ulp/definesdb.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 import os
 import btree
 from .util import file_exists

--- a/esp32_ulp/link.py
+++ b/esp32_ulp/link.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 from uctypes import struct, addressof, LITTLE_ENDIAN, UINT16, UINT32
 
 

--- a/esp32_ulp/nocomment.py
+++ b/esp32_ulp/nocomment.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 def remove_comments(s):
     """
     Remove comments of these styles:

--- a/esp32_ulp/opcodes.py
+++ b/esp32_ulp/opcodes.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 """
 ESP32 ULP Co-Processor Instructions
 """

--- a/esp32_ulp/opcodes_s2.py
+++ b/esp32_ulp/opcodes_s2.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 """
 ESP32 ULP Co-Processor Instructions
 """

--- a/esp32_ulp/parse_to_db.py
+++ b/esp32_ulp/parse_to_db.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 import sys
 
 from .preprocess import Preprocessor

--- a/esp32_ulp/preprocess.py
+++ b/esp32_ulp/preprocess.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 from . import nocomment
 from .util import split_tokens
 from .definesdb import DefinesDB

--- a/esp32_ulp/soc.py
+++ b/esp32_ulp/soc.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 """
 Address / Register definitions for the ESP32 SoC
 """

--- a/esp32_ulp/soc_s2.py
+++ b/esp32_ulp/soc_s2.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 """
 Address / Register definitions for the ESP32-S2 SoC
 """

--- a/esp32_ulp/soc_s3.py
+++ b/esp32_ulp/soc_s3.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 """
 Address / Register definitions for the ESP32-S3 SoC
 """

--- a/esp32_ulp/util.py
+++ b/esp32_ulp/util.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 DEBUG = False
 
 import gc

--- a/examples/blink.py
+++ b/examples/blink.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 """
 Example for: ESP32
 

--- a/examples/blink_s2.py
+++ b/examples/blink_s2.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 """
 Example for: ESP32-S2 and ESP32-S3
 

--- a/examples/counter.py
+++ b/examples/counter.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 """
 Example for: ESP32
 

--- a/examples/counter_s2.py
+++ b/examples/counter_s2.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 """
 Example for: ESP32-S2 and ESP32-S3
 

--- a/examples/readgpio.py
+++ b/examples/readgpio.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 """
 Example for: ESP32
 

--- a/examples/readgpio_s2.py
+++ b/examples/readgpio_s2.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 """
 Example for: ESP32-S2
 

--- a/examples/readgpio_s3.py
+++ b/examples/readgpio_s3.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 """
 Example for: ESP32-S3
 

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 import re
 from setuptools import setup
 import sdist_upip

--- a/tests/00_unit_tests.sh
+++ b/tests/00_unit_tests.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
 
 # export PYTHONPATH=.:$PYTHONPATH
 

--- a/tests/01_compat_tests.sh
+++ b/tests/01_compat_tests.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
 
 # export PYTHONPATH=.:$PYTHONPATH
 

--- a/tests/02_compat_rtc_tests.sh
+++ b/tests/02_compat_rtc_tests.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
 
 # export PYTHONPATH=.:$PYTHONPATH
 

--- a/tests/03_disassembler_tests.sh
+++ b/tests/03_disassembler_tests.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
 
 set -e
 

--- a/tests/assemble.py
+++ b/tests/assemble.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 from esp32_ulp.assemble import Assembler, TEXT, DATA, BSS, REL, ABS
 from esp32_ulp.assemble import SymbolTable
 from esp32_ulp.nocomment import remove_comments

--- a/tests/compat/alu.S
+++ b/tests/compat/alu.S
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
             .text
             
             and r1, r2, r3

--- a/tests/compat/expr.S
+++ b/tests/compat/expr.S
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 # common example of real world code using expressions
   .set adc_channel, 6
 

--- a/tests/compat/fixes.S
+++ b/tests/compat/fixes.S
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 # This file tests various fixes to the assembler,
 # to ensure the binary output matches that of binutils.
 # a) support for left-aligned directives (e.g. .set without preceding whitespace)

--- a/tests/compat/io.S
+++ b/tests/compat/io.S
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
             .text
 
             reg_rd 0x3ff48000, 7, 0

--- a/tests/compat/jumps.S
+++ b/tests/compat/jumps.S
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
   .text
   .set const, 3
   .global const  # exporting symbol is required for binutils, not important for micropython-esp32-ulp

--- a/tests/compat/loadstore.esp32s2.S
+++ b/tests/compat/loadstore.esp32s2.S
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 .set  offs, 0x20
 .set  lab1, 0x01
 

--- a/tests/compat/memory.S
+++ b/tests/compat/memory.S
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
             .text
 
             ld r0, r1, 0

--- a/tests/compat/preprocess_simple.S
+++ b/tests/compat/preprocess_simple.S
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 #define GPIO 2
 #define BASE 0x100
 #define ADDR (BASE + GPIO)

--- a/tests/compat/reg.esp32.S
+++ b/tests/compat/reg.esp32.S
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 #include "soc/rtc_cntl_reg.h"
 #include "soc/soc_ulp.h"
 

--- a/tests/compat/reg.esp32s2.S
+++ b/tests/compat/reg.esp32s2.S
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 #include "soc/rtc_cntl_reg.h"
 #include "soc/soc_ulp.h"
 

--- a/tests/compat/sections.S
+++ b/tests/compat/sections.S
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
             .text
 
             nop

--- a/tests/compat/sleep.S
+++ b/tests/compat/sleep.S
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
             .text
 
             nop

--- a/tests/compat/symbols.S
+++ b/tests/compat/symbols.S
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
             .text
 
             .set constant42, 42

--- a/tests/decode.py
+++ b/tests/decode.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 from tools.decode import decode_instruction, get_instruction_fields
 import esp32_ulp.opcodes as opcodes
 import ubinascii

--- a/tests/decode_s2.py
+++ b/tests/decode_s2.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 from tools.decode_s2 import decode_instruction, get_instruction_fields
 import esp32_ulp.opcodes_s2 as opcodes
 import ubinascii

--- a/tests/definesdb.py
+++ b/tests/definesdb.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 import os
 
 from esp32_ulp.definesdb import DefinesDB, DBNAME

--- a/tests/fixtures/all_opcodes.esp32.S
+++ b/tests/fixtures/all_opcodes.esp32.S
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 .data
 empty: .long 0
 magic: .long 0xc0decafe

--- a/tests/fixtures/all_opcodes.esp32s2.S
+++ b/tests/fixtures/all_opcodes.esp32s2.S
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 .data
 empty: .long 0
 magic: .long 0xc0decafe

--- a/tests/fixtures/incl.h
+++ b/tests/fixtures/incl.h
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 #define CONST1 42
 #define MACRO(x,y) x+y
 #define MULTI_LINE abc \

--- a/tests/fixtures/incl2.h
+++ b/tests/fixtures/incl2.h
@@ -1,2 +1,9 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 #define CONST2 123
 #define CONST3 777

--- a/tests/link.py
+++ b/tests/link.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 from esp32_ulp.link import make_binary
 
 

--- a/tests/nocomment.py
+++ b/tests/nocomment.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 from esp32_ulp.nocomment import remove_comments
 
 ORIG = """\

--- a/tests/opcodes.py
+++ b/tests/opcodes.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 from uctypes import UINT32, BFUINT32, BF_POS, BF_LEN
 from esp32_ulp.opcodes import make_ins, make_ins_struct_def
 from esp32_ulp.opcodes import get_reg, get_imm, get_cond, arg_qualify, eval_arg, ARG, REG, IMM, SYM, COND

--- a/tests/opcodes_s2.py
+++ b/tests/opcodes_s2.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 from uctypes import UINT32, BFUINT32, BF_POS, BF_LEN
 from esp32_ulp.opcodes_s2 import make_ins, make_ins_struct_def
 from esp32_ulp.opcodes_s2 import get_reg, get_imm, get_cond, arg_qualify, eval_arg, ARG, REG, IMM, SYM, COND

--- a/tests/preprocess.py
+++ b/tests/preprocess.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 import os
 
 from esp32_ulp.preprocess import Preprocessor

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 import os
 from esp32_ulp.util import split_tokens, validate_expression, file_exists
 

--- a/tools/decode.py
+++ b/tools/decode.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 import esp32_ulp.opcodes as opcodes
 
 

--- a/tools/decode_s2.py
+++ b/tools/decode_s2.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 import esp32_ulp.opcodes_s2 as opcodes
 
 

--- a/tools/disassemble.py
+++ b/tools/disassemble.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 from uctypes import struct, addressof, LITTLE_ENDIAN, UINT16, UINT32
 import ubinascii
 import sys

--- a/tools/genpkgjson.py
+++ b/tools/genpkgjson.py
@@ -1,3 +1,10 @@
+#
+# This file is part of the micropython-esp32-ulp project,
+# https://github.com/micropython/micropython-esp32-ulp
+#
+# SPDX-FileCopyrightText: 2018-2023, the micropython-esp32-ulp authors, see AUTHORS file.
+# SPDX-License-Identifier: MIT
+
 """
 Tool for generating package.json for the MIP package manager
 


### PR DESCRIPTION
This PR adds a licence header to every source code file to make it very clear for anyone who copies the given file what the licence/copyright is.

Closes #90 