### PR TITLE
Add src_to_binary_ext that returns addrs_syms

### DIFF
--- a/esp32_ulp/__init__.py
+++ b/esp32_ulp/__init__.py
@@ -12,19 +12,20 @@ from .assemble import Assembler
 from .link import make_binary
 garbage_collect('after import')
 
-
-def src_to_binary(src, cpu):
+def src_to_binary_ext(src, cpu):
     assembler = Assembler(cpu)
     src = preprocess(src)
     assembler.assemble(src, remove_comments=False)  # comments already removed by preprocessor
     garbage_collect('before symbols export')
     addrs_syms = assembler.symbols.export()
+    text, data, bss_len = assembler.fetch()
+    return make_binary(text, data, bss_len), addrs_syms
+
+def src_to_binary(src, cpu):
+    binary, addrs_syms = src_to_binary_ext(src, cpu)
     for addr, sym in addrs_syms:
         print('%04d %s' % (addr, sym))
-
-    text, data, bss_len = assembler.fetch()
-    return make_binary(text, data, bss_len)
-
+    return binary
 
 def assemble_file(filename, cpu):
     with open(filename) as f:


### PR DESCRIPTION
This PR adds a `src_to_binary_ext` function that assembles the binary, collects the addresses of symbols, and returns them.
It also alters the existing `src_to_binary` function to use it in order to print the addresses of symbols out and only return the binary.

This change was necessary, as I had the requirement to know the addresses of symbols to replace them in resulting code segments, and I think it makes sense to not just print the symbols out but to have them available programatically.

Please let me know if there is any further guideline I should follow to get this PR merged - happy to adjust and collaborate.