### PR TITLE
Fix compat tests due to esp-idf moving include files

### DIFF
--- a/tests/01_compat_tests.sh
+++ b/tests/01_compat_tests.sh
@@ -53,6 +53,7 @@ run_tests_for_cpu() {
 
         echo -e "\tBuilding using binutils ($cpu)"
         gcc -I esp-idf/components/soc/$cpu/include -I esp-idf/components/esp_common/include \
+            -I esp-idf/components/soc/$cpu/register \
             -x assembler-with-cpp \
             -E -o ${pre_file} $src_file
         esp32ulp-elf-as --mcpu=$cpu -o $obj_file ${pre_file}

--- a/tests/02_compat_rtc_tests.sh
+++ b/tests/02_compat_rtc_tests.sh
@@ -61,6 +61,7 @@ build_defines_db() {
     rm -f "${defines_db}"
     micropython -m esp32_ulp.parse_to_db \
         esp-idf/components/soc/$cpu/include/soc/*.h \
+        esp-idf/components/soc/$cpu/register/soc/*.h \
         esp-idf/components/esp_common/include/*.h 1>$log_file
 
     # cache defines.db
@@ -184,6 +185,7 @@ run_tests_for_cpu() {
 
         echo -e "\tBuilding using binutils ($cpu)"
         gcc -I esp-idf/components/soc/$cpu/include -I esp-idf/components/esp_common/include \
+            -I esp-idf/components/soc/$cpu/register \
             -x assembler-with-cpp \
             -E -o ${pre_file} $src_file
         esp32ulp-elf-as --mcpu=$cpu -o $obj_file ${pre_file}


### PR DESCRIPTION
Peripheral register definitions were moved to a new directory inside the ESP-IDF: components/soc/{cpu_type}/register.

This change caused our compat tests to fail because they depended on predefined register constants.

This PR resolves the issue by adding the new directory to GCC's include search path using the -I option.

Additionally, all header files in this new directory are now added to the DefinesDB for the compat tests with RTC macros.

Fixes #101.