### PR TITLE
Update builder image to ubuntu-22.04

### DIFF
--- a/.github/workflows/run_tests.yaml
+++ b/.github/workflows/run_tests.yaml
@@ -11,7 +11,7 @@ on: [push, pull_request]
 
 jobs:
   tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
GitHub has deprecated and removed the ubuntu-20.04 builder image.
This PR updates the build process to use the ubuntu-22.04 image instead.
Tested locally with [act](https://nektosact.com/) that all tests still pass.

GitHub's announcement: https://github.com/actions/runner-images/issues/11101